### PR TITLE
Update kia_v1.c

### DIFF
--- a/protocols/kia_v1.c
+++ b/protocols/kia_v1.c
@@ -91,7 +91,7 @@ static inline bool kia_v1_get_raw_bit(SubGhzProtocolDecoderKiaV1 *instance, uint
 
 static bool kia_v1_manchester_decode(SubGhzProtocolDecoderKiaV1 *instance)
 {
-    if (instance->raw_bit_count < 113)
+    if (instance->raw_bit_count < 112)
     {
         FURI_LOG_D(TAG, "Not enough raw bits: %u", instance->raw_bit_count);
         return false;


### PR DESCRIPTION
Fix Kia V1 decoder: accept 112 raw bits instead of 113