### PR TITLE
Add emulate feature to receiver info scene

### DIFF
--- a/helpers/protopirate_types.h
+++ b/helpers/protopirate_types.h
@@ -24,6 +24,7 @@ typedef enum {
     ProtoPirateCustomEventSceneSettingLock,
     // File management
     ProtoPirateCustomEventReceiverInfoSave,
+    ProtoPirateCustomEventReceiverInfoEmulate,
     ProtoPirateCustomEventSavedInfoDelete,
     // Emulator
     ProtoPirateCustomEventSavedInfoEmulate,


### PR DESCRIPTION
Introduces a new custom event and button for emulating receiver info when ENABLE_EMULATE_FEATURE is defined. The emulate action saves the current protocol data and transitions to the emulate scene, with appropriate logging and error handling.