### PR TITLE
Add encoder implementation for Fiat V0 protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Decoders:
 
 Encoders:
 
+- Fiat V0
 - Ford V0
 - KIA V0
 - KIA V1

--- a/protocols/fiat_v0.c
+++ b/protocols/fiat_v0.c
@@ -10,6 +10,11 @@ static const SubGhzBlockConst subghz_protocol_fiat_v0_const = {
     .min_count_bit_for_found = 64,
 };
 
+#define FIAT_V0_PREAMBLE_PAIRS   150
+#define FIAT_V0_GAP_US           800
+#define FIAT_V0_TOTAL_BURSTS     3
+#define FIAT_V0_INTER_BURST_GAP  25000
+
 struct SubGhzProtocolDecoderFiatV0 {
     SubGhzProtocolDecoderBase base;
     SubGhzBlockDecoder decoder;
@@ -20,10 +25,9 @@ struct SubGhzProtocolDecoderFiatV0 {
     uint32_t data_low;
     uint32_t data_high;
     uint8_t bit_count;
-    uint32_t hop;
-    uint32_t fix;
-    uint8_t endbyte;
-    uint8_t final_count;
+    uint32_t cnt;
+    uint32_t serial;
+    uint8_t btn;
     uint32_t te_last;
 };
 
@@ -31,6 +35,10 @@ struct SubGhzProtocolEncoderFiatV0 {
     SubGhzProtocolEncoderBase base;
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
+
+    uint32_t cnt;
+    uint32_t serial;
+    uint8_t btn;
 };
 
 typedef enum {
@@ -51,20 +59,277 @@ const SubGhzProtocolDecoder subghz_protocol_fiat_v0_decoder = {
 };
 
 const SubGhzProtocolEncoder subghz_protocol_fiat_v0_encoder = {
-    .alloc = NULL,
-    .free = NULL,
-    .deserialize = NULL,
-    .stop = NULL,
-    .yield = NULL,
+    .alloc = subghz_protocol_encoder_fiat_v0_alloc,
+    .free = subghz_protocol_encoder_fiat_v0_free,
+    .deserialize = subghz_protocol_encoder_fiat_v0_deserialize,
+    .stop = subghz_protocol_encoder_fiat_v0_stop,
+    .yield = subghz_protocol_encoder_fiat_v0_yield,
 };
 
 const SubGhzProtocol fiat_protocol_v0 = {
     .name = FIAT_PROTOCOL_V0_NAME,
     .type = SubGhzProtocolTypeDynamic,
-    .flag = SubGhzProtocolFlag_433 | SubGhzProtocolFlag_FM | SubGhzProtocolFlag_Decodable,
+    .flag = SubGhzProtocolFlag_433 | SubGhzProtocolFlag_FM | SubGhzProtocolFlag_Decodable |
+            SubGhzProtocolFlag_Load | SubGhzProtocolFlag_Save | SubGhzProtocolFlag_Send,
     .decoder = &subghz_protocol_fiat_v0_decoder,
     .encoder = &subghz_protocol_fiat_v0_encoder,
 };
+
+// ============================================================================
+// ENCODER IMPLEMENTATION
+// ============================================================================
+
+void* subghz_protocol_encoder_fiat_v0_alloc(SubGhzEnvironment* environment) {
+    UNUSED(environment);
+    SubGhzProtocolEncoderFiatV0* instance = malloc(sizeof(SubGhzProtocolEncoderFiatV0));
+
+    instance->base.protocol = &fiat_protocol_v0;
+    instance->generic.protocol_name = instance->base.protocol->name;
+
+    instance->encoder.repeat = 10;
+    instance->encoder.size_upload = 2048;
+    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
+    instance->encoder.is_running = false;
+    instance->encoder.front = 0;
+
+    instance->cnt = 0;
+    instance->serial = 0;
+    instance->btn = 0;
+
+    return instance;
+}
+
+void subghz_protocol_encoder_fiat_v0_free(void* context) {
+    furi_assert(context);
+    SubGhzProtocolEncoderFiatV0* instance = context;
+    if(instance->encoder.upload) {
+        free(instance->encoder.upload);
+    }
+    free(instance);
+}
+
+static void subghz_protocol_encoder_fiat_v0_get_upload(SubGhzProtocolEncoderFiatV0* instance) {
+    furi_assert(instance);
+    size_t index = 0;
+
+    uint32_t te_short = subghz_protocol_fiat_v0_const.te_short;
+    uint32_t te_long = subghz_protocol_fiat_v0_const.te_long;
+
+    FURI_LOG_I(
+        TAG,
+        "Building upload: cnt=0x%08lX, serial=0x%08lX, btn=0x%02X",
+        instance->cnt,
+        instance->serial,
+        instance->btn);
+
+    uint64_t data = ((uint64_t)instance->cnt << 32) | instance->serial;
+
+    // Reverse the decoder's btn fix: decoder does (x << 1) | 1
+    uint8_t btn_to_send = instance->btn >> 1;
+
+    for(uint8_t burst = 0; burst < FIAT_V0_TOTAL_BURSTS; burst++) {
+        if(burst > 0) {
+            instance->encoder.upload[index++] = level_duration_make(false, FIAT_V0_INTER_BURST_GAP);
+        }
+
+        // Preamble: HIGH-LOW pairs
+        for(int i = 0; i < FIAT_V0_PREAMBLE_PAIRS; i++) {
+            instance->encoder.upload[index++] = level_duration_make(true, te_short);
+            instance->encoder.upload[index++] = level_duration_make(false, te_short);
+        }
+
+        // Replace last preamble LOW with gap
+        instance->encoder.upload[index - 1] = level_duration_make(false, FIAT_V0_GAP_US);
+
+        // First bit (bit 63) - special handling after gap
+        bool first_bit = (data >> 63) & 1;
+        if(first_bit) {
+            // First bit is 1: LONG HIGH
+            instance->encoder.upload[index++] = level_duration_make(true, te_long);
+        } else {
+            // First bit is 0: SHORT HIGH + LONG LOW
+            instance->encoder.upload[index++] = level_duration_make(true, te_short);
+            instance->encoder.upload[index++] = level_duration_make(false, te_long);
+        }
+
+        bool prev_bit = first_bit;
+
+        // Encode remaining 63 data bits (bits 62:0) using differential Manchester
+        for(int bit = 62; bit >= 0; bit--) {
+            bool curr_bit = (data >> bit) & 1;
+
+            if(!prev_bit && !curr_bit) {
+                // 0->0: SHORT HIGH + SHORT LOW
+                instance->encoder.upload[index++] = level_duration_make(true, te_short);
+                instance->encoder.upload[index++] = level_duration_make(false, te_short);
+            } else if(!prev_bit && curr_bit) {
+                // 0->1: LONG HIGH
+                instance->encoder.upload[index++] = level_duration_make(true, te_long);
+            } else if(prev_bit && !curr_bit) {
+                // 1->0: LONG LOW
+                instance->encoder.upload[index++] = level_duration_make(false, te_long);
+            } else {
+                // 1->1: SHORT LOW + SHORT HIGH
+                instance->encoder.upload[index++] = level_duration_make(false, te_short);
+                instance->encoder.upload[index++] = level_duration_make(true, te_short);
+            }
+
+            prev_bit = curr_bit;
+        }
+
+        // Encode 6 btn bits using same differential pattern
+        for(int bit = 5; bit >= 0; bit--) {
+            bool curr_bit = (btn_to_send >> bit) & 1;
+
+            if(!prev_bit && !curr_bit) {
+                instance->encoder.upload[index++] = level_duration_make(true, te_short);
+                instance->encoder.upload[index++] = level_duration_make(false, te_short);
+            } else if(!prev_bit && curr_bit) {
+                instance->encoder.upload[index++] = level_duration_make(true, te_long);
+            } else if(prev_bit && !curr_bit) {
+                instance->encoder.upload[index++] = level_duration_make(false, te_long);
+            } else {
+                instance->encoder.upload[index++] = level_duration_make(false, te_short);
+                instance->encoder.upload[index++] = level_duration_make(true, te_short);
+            }
+
+            prev_bit = curr_bit;
+        }
+
+        // End marker - ensure we end with LOW
+        if(prev_bit) {
+            instance->encoder.upload[index++] = level_duration_make(false, te_short);
+        }
+        instance->encoder.upload[index++] = level_duration_make(false, te_short * 8);
+    }
+
+    instance->encoder.size_upload = index;
+    instance->encoder.front = 0;
+
+    FURI_LOG_I(TAG, "Upload built: %zu elements, btn_to_send=0x%02X",
+        instance->encoder.size_upload, btn_to_send);
+}
+
+SubGhzProtocolStatus
+    subghz_protocol_encoder_fiat_v0_deserialize(void* context, FlipperFormat* flipper_format) {
+    furi_assert(context);
+    SubGhzProtocolEncoderFiatV0* instance = context;
+    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
+
+    instance->encoder.is_running = false;
+    instance->encoder.front = 0;
+    instance->encoder.repeat = 10;
+
+    flipper_format_rewind(flipper_format);
+
+    do {
+        FuriString* temp_str = furi_string_alloc();
+        if(!flipper_format_read_string(flipper_format, "Protocol", temp_str)) {
+            FURI_LOG_E(TAG, "Missing Protocol");
+            furi_string_free(temp_str);
+            break;
+        }
+
+        if(!furi_string_equal(temp_str, instance->base.protocol->name)) {
+            FURI_LOG_E(TAG, "Wrong protocol: %s", furi_string_get_cstr(temp_str));
+            furi_string_free(temp_str);
+            break;
+        }
+        furi_string_free(temp_str);
+
+        uint32_t bit_count_temp;
+        if(!flipper_format_read_uint32(flipper_format, "Bit", &bit_count_temp, 1)) {
+            FURI_LOG_E(TAG, "Missing Bit");
+            break;
+        }
+
+        temp_str = furi_string_alloc();
+        if(!flipper_format_read_string(flipper_format, "Key", temp_str)) {
+            FURI_LOG_E(TAG, "Missing Key");
+            furi_string_free(temp_str);
+            break;
+        }
+
+        const char* key_str = furi_string_get_cstr(temp_str);
+        uint64_t key = 0;
+        size_t str_len = strlen(key_str);
+        size_t hex_pos = 0;
+
+        for(size_t i = 0; i < str_len && hex_pos < 16; i++) {
+            char c = key_str[i];
+            if(c == ' ') continue;
+
+            uint8_t nibble;
+            if(c >= '0' && c <= '9')
+                nibble = c - '0';
+            else if(c >= 'A' && c <= 'F')
+                nibble = c - 'A' + 10;
+            else if(c >= 'a' && c <= 'f')
+                nibble = c - 'a' + 10;
+            else
+                break;
+
+            key = (key << 4) | nibble;
+            hex_pos++;
+        }
+        furi_string_free(temp_str);
+
+        instance->generic.data = key;
+        instance->cnt = (uint32_t)(key >> 32);
+        instance->serial = (uint32_t)(key & 0xFFFFFFFF);
+
+        uint32_t btn_temp = 0;
+        if(flipper_format_read_uint32(flipper_format, "Btn", &btn_temp, 1)) {
+            instance->btn = (uint8_t)btn_temp;
+        } else {
+            instance->btn = 0;
+        }
+
+        if(!flipper_format_read_uint32(
+               flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1)) {
+            instance->encoder.repeat = 10;
+        }
+
+        subghz_protocol_encoder_fiat_v0_get_upload(instance);
+        instance->encoder.is_running = true;
+
+        FURI_LOG_I(TAG, "Encoder ready: cnt=0x%08lX, serial=0x%08lX, btn=0x%02X",
+            instance->cnt, instance->serial, instance->btn);
+
+        ret = SubGhzProtocolStatusOk;
+    } while(false);
+
+    return ret;
+}
+
+void subghz_protocol_encoder_fiat_v0_stop(void* context) {
+    furi_assert(context);
+    SubGhzProtocolEncoderFiatV0* instance = context;
+    instance->encoder.is_running = false;
+}
+
+LevelDuration subghz_protocol_encoder_fiat_v0_yield(void* context) {
+    furi_assert(context);
+    SubGhzProtocolEncoderFiatV0* instance = context;
+
+    if(!instance->encoder.is_running || instance->encoder.repeat == 0) {
+        instance->encoder.is_running = false;
+        return level_duration_reset();
+    }
+
+    LevelDuration ret = instance->encoder.upload[instance->encoder.front];
+
+    if(++instance->encoder.front == instance->encoder.size_upload) {
+        instance->encoder.repeat--;
+        instance->encoder.front = 0;
+    }
+
+    return ret;
+}
+
+// ============================================================================
+// DECODER IMPLEMENTATION
+// ============================================================================
 
 void* subghz_protocol_decoder_fiat_v0_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
@@ -89,10 +354,9 @@ void subghz_protocol_decoder_fiat_v0_reset(void* context) {
     instance->data_low = 0;
     instance->data_high = 0;
     instance->bit_count = 0;
-    instance->hop = 0;
-    instance->fix = 0;
-    instance->endbyte = 0;
-    instance->final_count = 0;
+    instance->cnt = 0;
+    instance->serial = 0;
+    instance->btn = 0;
     instance->te_last = 0;
     instance->manchester_state = ManchesterStateMid1;
 }
@@ -105,6 +369,7 @@ void subghz_protocol_decoder_fiat_v0_feed(void* context, bool level, uint32_t du
     uint32_t te_delta = (uint32_t)subghz_protocol_fiat_v0_const.te_delta;
     uint32_t gap_threshold = 800;
     uint32_t diff;
+
     switch(instance->decoder_state) {
     case FiatV0DecoderStepReset:
         if(!level) {
@@ -129,6 +394,7 @@ void subghz_protocol_decoder_fiat_v0_feed(void* context, bool level, uint32_t du
                 NULL);
         }
         break;
+
     case FiatV0DecoderStepPreamble:
         if(level) {
             return;
@@ -199,7 +465,8 @@ void subghz_protocol_decoder_fiat_v0_feed(void* context, bool level, uint32_t du
             }
         }
         break;
-    case FiatV0DecoderStepData:
+
+    case FiatV0DecoderStepData: {
         ManchesterEvent event = ManchesterEventReset;
         if(duration < te_short) {
             diff = te_short - duration;
@@ -238,23 +505,20 @@ void subghz_protocol_decoder_fiat_v0_feed(void* context, bool level, uint32_t du
                 instance->bit_count++;
 
                 if(instance->bit_count == 0x40) {
-                    instance->fix = instance->data_low;
-                    instance->hop = instance->data_high;
+                    instance->serial = instance->data_low;
+                    instance->cnt = instance->data_high;
                     instance->data_low = 0;
                     instance->data_high = 0;
                 }
 
                 if(instance->bit_count > 0x46) {
-                    instance->final_count = instance->bit_count;
+                    instance->btn = (uint8_t)((instance->data_low << 1) | 1);
 
-                    instance->endbyte = (uint8_t)instance->data_low;
-
-                    instance->generic.data = ((uint64_t)instance->hop << 32) | instance->fix;
-                    instance->generic.data_count_bit = 64;
-                    instance->generic.serial = instance->fix;
-                    instance->generic.btn =
-                        instance->endbyte; // still exported as btn for UI compatibility
-                    instance->generic.cnt = instance->hop;
+                    instance->generic.data = ((uint64_t)instance->cnt << 32) | instance->serial;
+                    instance->generic.data_count_bit = 71;
+                    instance->generic.serial = instance->serial;
+                    instance->generic.btn = instance->btn;
+                    instance->generic.cnt = instance->cnt;
 
                     if(instance->base.callback) {
                         instance->base.callback(&instance->base, instance->base.context);
@@ -269,6 +533,7 @@ void subghz_protocol_decoder_fiat_v0_feed(void* context, bool level, uint32_t du
         }
         instance->te_last = duration;
         break;
+    }
     }
 }
 
@@ -287,7 +552,33 @@ SubGhzProtocolStatus subghz_protocol_decoder_fiat_v0_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderFiatV0* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+
+    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
+
+    do {
+        if(!flipper_format_write_uint32(flipper_format, "Frequency", &preset->frequency, 1)) break;
+        if(!flipper_format_write_string_cstr(
+               flipper_format, "Preset", furi_string_get_cstr(preset->name))) break;
+        if(!flipper_format_write_string_cstr(
+               flipper_format, "Protocol", instance->generic.protocol_name)) break;
+
+        uint32_t bits = 71;
+        if(!flipper_format_write_uint32(flipper_format, "Bit", &bits, 1)) break;
+
+        char key_str[20];
+        snprintf(key_str, sizeof(key_str), "%08lX%08lX", instance->cnt, instance->serial);
+        if(!flipper_format_write_string_cstr(flipper_format, "Key", key_str)) break;
+
+        if(!flipper_format_write_uint32(flipper_format, "Cnt", &instance->cnt, 1)) break;
+        if(!flipper_format_write_uint32(flipper_format, "Serial", &instance->serial, 1)) break;
+
+        uint32_t temp = instance->btn;
+        if(!flipper_format_write_uint32(flipper_format, "Btn", &temp, 1)) break;
+
+        ret = SubGhzProtocolStatusOk;
+    } while(false);
+
+    return ret;
 }
 
 SubGhzProtocolStatus
@@ -302,21 +593,17 @@ void subghz_protocol_decoder_fiat_v0_get_string(void* context, FuriString* outpu
     furi_assert(context);
     SubGhzProtocolDecoderFiatV0* instance = context;
 
-    uint32_t code_found_hi = instance->hop;
-    uint32_t code_found_lo = instance->fix;
-
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:%08lX%08lX\r\n"
-        "Hop:%08lX\r\n"
-        "Fix:%08lX\r\n"
-        "EndByte:%02X\r\n",
+        "Sn:%08lX Btn:%02X\r\n"
+        "Cnt:%08lX\r\n",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
-        code_found_hi,
-        code_found_lo,
-        instance->hop,
-        instance->fix,
-        instance->endbyte);
+        instance->cnt,
+        instance->serial,
+        instance->serial,
+        instance->btn,
+        instance->cnt);
 }

--- a/protocols/fiat_v0.h
+++ b/protocols/fiat_v0.h
@@ -13,9 +13,11 @@
 #define FIAT_PROTOCOL_V0_NAME "Fiat V0"
 
 typedef struct SubGhzProtocolDecoderFiatV0 SubGhzProtocolDecoderFiatV0;
+typedef struct SubGhzProtocolEncoderFiatV0 SubGhzProtocolEncoderFiatV0;
 
 extern const SubGhzProtocol fiat_protocol_v0;
 
+// Decoder functions
 void* subghz_protocol_decoder_fiat_v0_alloc(SubGhzEnvironment* environment);
 void subghz_protocol_decoder_fiat_v0_free(void* context);
 void subghz_protocol_decoder_fiat_v0_reset(void* context);
@@ -28,3 +30,11 @@ SubGhzProtocolStatus subghz_protocol_decoder_fiat_v0_serialize(
 SubGhzProtocolStatus
     subghz_protocol_decoder_fiat_v0_deserialize(void* context, FlipperFormat* flipper_format);
 void subghz_protocol_decoder_fiat_v0_get_string(void* context, FuriString* output);
+
+// Encoder functions
+void* subghz_protocol_encoder_fiat_v0_alloc(SubGhzEnvironment* environment);
+void subghz_protocol_encoder_fiat_v0_free(void* context);
+SubGhzProtocolStatus
+    subghz_protocol_encoder_fiat_v0_deserialize(void* context, FlipperFormat* flipper_format);
+void subghz_protocol_encoder_fiat_v0_stop(void* context);
+LevelDuration subghz_protocol_encoder_fiat_v0_yield(void* context);


### PR DESCRIPTION
Implemented the encoder for the Fiat V0 SubGhz protocol, including allocation, serialization, and signal generation logic. Updated the decoder and related data structures for consistency, improved serialization/deserialization, and added protocol flags for encoding support. Updated README to list Fiat V0 as an encoder.