### PR TITLE
Change CRC calculation offset from 1 to 15

### DIFF
--- a/protocols/kia_v1.c
+++ b/protocols/kia_v1.c
@@ -108,7 +108,7 @@ static void kia_v1_check_remote_controller(SubGhzProtocolDecoderKiaV1* instance)
         crc = kia_v1_crc4(char_data, 6, offset);
     } else if(cnt_high >= 0x6) {
         char_data[6] = cnt_high;
-        crc = kia_v1_crc4(char_data, 7, 1);
+        crc = kia_v1_crc4(char_data, 7, 15);
     } else {
         crc = kia_v1_crc4(char_data, 6, 1);
     }
@@ -176,7 +176,7 @@ static void kia_protocol_encoder_v1_get_upload(SubGhzProtocolEncoderKiaV1* insta
         crc = kia_v1_crc4(char_data, 6, offset);
     } else if(cnt_high >= 0x6) {
         char_data[6] = cnt_high;
-        crc = kia_v1_crc4(char_data, 7, 1);
+        crc = kia_v1_crc4(char_data, 7, 15);
     } else {
         crc = kia_v1_crc4(char_data, 6, 1);
     }


### PR DESCRIPTION
Possible fix for this Strange crc Bug.
Need more KiaV1 subs for Testing but Looks good with my Samples.

updates `protocols/kia_v1.c` to use `offset = 15` when `cnt_high >= 6`, in both the decoder and encoder.