### PR TITLE
Add BS Magic to Saved Info View, make visible in Received.

### DIFF
--- a/protocols/ford_v0.c
+++ b/protocols/ford_v0.c
@@ -949,11 +949,14 @@ void subghz_protocol_decoder_ford_v0_get_string(void* context, FuriString* outpu
     furi_string_cat_printf(
         output,
         "%s %dbit CRC:%s\r\n"
-        "Key1:%08lX%08lX\r\n"
-        "Key2:%04X\r\n"
-        "Sn:%08lX Btn:%02X:%s\r\n"
-        "Cnt:%05lX BS:%02X CRC:%02X\r\n"
-        "BSMagic:%02X\r\n",
+        "Key1: %08lX%08lX\r\n"
+        "Key2: %04X"
+        "  Sn: %08lX\r\n"
+        "Cnt: %05lX"
+        "  BS: %02X"
+        "  CRC: %02X\r\n"
+        "BS Magic: %02X"
+        "  Btn: %02X - %s\r\n",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         crc_ok ? "OK" : "BAD",
@@ -961,10 +964,11 @@ void subghz_protocol_decoder_ford_v0_get_string(void* context, FuriString* outpu
         (unsigned long)code_found_lo,
         instance->key2,
         (unsigned long)instance->serial,
-        instance->button,
-        button_name,
+
         (unsigned long)instance->count,
         (instance->key2 >> 8) & 0xFF,
         instance->key2 & 0xFF,
-        instance->bs_magic);
+        instance->bs_magic,
+        instance->button,
+        button_name);
 }

--- a/scenes/protopirate_scene_saved_info.c
+++ b/scenes/protopirate_scene_saved_info.c
@@ -67,6 +67,12 @@ void protopirate_scene_saved_info_on_enter(void* context) {
                 furi_string_cat_printf(info_str, "Counter: %04lX\n", temp_data);
             }
 
+            // BS
+            flipper_format_rewind(ff);
+            if(flipper_format_read_uint32(ff, "BS", &temp_data, 1)) {
+                furi_string_cat_printf(info_str, "BS: %02X\n", (uint8_t)temp_data);
+            }
+
             // BS Magic
             flipper_format_rewind(ff);
             if(flipper_format_read_uint32(ff, "BSMagic", &temp_data, 1)) {


### PR DESCRIPTION
Now that the BS Magic code has been Merged, it would be nice to see it on screen in the Receiver and Saved Info Views. BS Magic is in _get_string, but is chopped because of it's on too many lines to fit on screen.

This P.R. adds BS Magic to Saved Info View, and Refactors the _get_string function to return a string that fits all Values on screen. 

Now we wont have to download the PSF files to a PC to see all the relevant values and test new remotes.