### PR TITLE
FORD: Update PSF with new BS and CRC after TX

### DIFF
--- a/protocols/ford_v0.c
+++ b/protocols/ford_v0.c
@@ -637,6 +637,14 @@ SubGhzProtocolStatus
             break;
         }
 
+        //Update the PSF file, since we have overwritten the COUNTER and BUTTON
+        //This makes the file's nummers wrong, and fails tests. It wasnt causing a TX bug, but manual tests failed.
+        flipper_format_rewind(flipper_format);
+        uint32_t temp = calculated_crc;
+        flipper_format_insert_or_update_uint32(flipper_format, "CRC", &temp, 1);
+        temp = instance->bs;
+        flipper_format_insert_or_update_uint32(flipper_format, "BS", &temp, 1);
+
         instance->encoder.is_running = true;
 
         FURI_LOG_I(


### PR DESCRIPTION
When a Saved Fob is Emulated, the BS and CRC are not updating in the fille. 

This doesnt cause a bug in TX, but causes the file to show outdated values that dont match the counter and button.

This causes the PSF files to fail tests, and  has cause confusion for Developeres during testing of overflow bug correctiion PR.

This PR updates the BS and CRC in the PSF file.